### PR TITLE
fix FP issue, minor adjustment for more accurate royalties

### DIFF
--- a/examples/tensor/buy-floor/route.ts
+++ b/examples/tensor/buy-floor/route.ts
@@ -42,7 +42,9 @@ app.openapi(createRoute({
       },
     );
   }
-  const buyNowPriceNetFees = await getListingsByCollection(collection.collId)
+  const buyNowPriceNetFees = collection.stats.buyNowPriceNetFees 
+  ? parseInt(collection.stats.buyNowPriceNetFees)
+  : await getListingsByCollection(collection.collId)
     .then(resp => getTotalPrice(
       parseInt(resp.mints[0].listing.price), 
       collection.sellRoyaltyFeeBPS,

--- a/examples/tensor/buy-floor/transaction-utils.ts
+++ b/examples/tensor/buy-floor/transaction-utils.ts
@@ -1,7 +1,12 @@
 import { getNftBuyTransaction, Mint } from '../../../api/tensor-api';
 import { connection } from '../../../shared/connection';
 
-const TENSOR_FEE_BPS = 150; // both for NFT and cNFT
+const SOURCE_TO_FEE_BPS = {
+  "TENSORSWAP": 150,
+  "TCOMP": 150,
+  "MAGICEDEN_V2": 250,
+  "default": 150
+}
 
 export async function createBuyNftTransaction(
   mint: Mint,
@@ -14,6 +19,7 @@ export async function createBuyNftTransaction(
   const totalPrice = getTotalPrice(
     parseInt(mint.listing.price, 10),
     mint.royaltyBps,
+    mint.listing.source
   );
   return getNftBuyTransaction({
     mintAddress: mint.mint,
@@ -24,9 +30,13 @@ export async function createBuyNftTransaction(
   });
 }
 
-function getTotalPrice(price: number, royaltyBps: number): number {
+export function getTotalPrice(price: number, royaltyBps: number, source: keyof typeof SOURCE_TO_FEE_BPS | string): number {
+  const MP_FEE_BPS = source in SOURCE_TO_FEE_BPS 
+    ? SOURCE_TO_FEE_BPS[source as keyof typeof SOURCE_TO_FEE_BPS]
+    : SOURCE_TO_FEE_BPS["default"];
   const royalty = (price * royaltyBps) / 10000;
-  const marketPlaceFee = (price * TENSOR_FEE_BPS) / 10000;
+  const marketPlaceFee = (price * MP_FEE_BPS) / 10000;
 
   return price + royalty + marketPlaceFee;
 }
+


### PR DESCRIPTION
`stats.buyNowPrice` / `stats.buyNowPriceNetFees` fields are not the ground truth - they can be `undefined` for some collections in edge cases, leading to incorrect "Collection has no listed NFTs" responses, even when there are listed NFTs.
==> re-uses `getListingsByCollection` if price fields are undefined for more reliable responses

Made a small adjustment for calculating royalties to reflect floor prices more accurately.