### PR TITLE
Added examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ e.g action for swap on Jupiter: <localhost:3000/api/jupiter/swap/SOL-Bonk>
 
 ## Examples in this repo
 
-There is a donate r
+There is a simple donate action in this repo which serves as a template for creating your own actions.
 
 There are also a few example actions in this repository for [Jupiter](examples/jupiter-swap/route.ts) (swap), [Helius](examples/helius/stake/route.ts) (stake), [Meteora](examples/meteora/swap/route.ts) (swap), [Sanctum](examples/sanctum/trade/route.ts) (stake), and [Tensor](examples/tensor) (buy floor or bid).
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ To check and unfurl your or existing action open
 [https://actions.dialect.to/](https://actions.dialect.to/)  
 e.g action for swap on Jupiter: <localhost:3000/api/jupiter/swap/SOL-Bonk>
 
+## Examples in this repo
+
+There is a donate r
+
+There are also a few example actions in this repository for [Jupiter](examples/jupiter-swap/route.ts) (swap), [Helius](examples/helius/stake/route.ts) (stake), [Meteora](examples/meteora/swap/route.ts) (swap), [Sanctum](examples/sanctum/trade/route.ts) (stake), and [Tensor](examples/tensor) (buy floor or bid).
+
+You can find the code for these actions in the [examples](examples) directory.
+
+You can also unfurl these actions into Blinks on https://dial.to by entering the action URL into the Blink URL field.
+
+For example, to unfurl the Helius stake action, you would enter the following URL into the Blink URL field:
+
+`http://localhost:3000/api/helius/stake`
+
+
 ## Learn More
 To learn more about Hono, take a look at the following resources:
 


### PR DESCRIPTION
Adding the following to the README:

## Examples in this repo

There is a donate r

There are also a few example actions in this repository for [Jupiter](examples/jupiter-swap/route.ts) (swap), [Helius](examples/helius/stake/route.ts) (stake), [Meteora](examples/meteora/swap/route.ts) (swap), [Sanctum](examples/sanctum/trade/route.ts) (stake), and [Tensor](examples/tensor) (buy floor or bid).

You can find the code for these actions in the [examples](examples) directory.

You can also unfurl these actions into Blinks on https://dial.to by entering the action URL into the Blink URL field.

For example, to unfurl the Helius stake action, you would enter the following URL into the Blink URL field:

`http://localhost:3000/api/helius/stake`